### PR TITLE
fix: always place git-squad content into the footer section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - allow passing multiple buddies to `without` command
 - add tab completions for buddies aliases
 
+### Fixes
+
+- always place co-authors in footer section of the commit
+
 ## 0.2.0 -- 2025-04-04
 
 ### Features

--- a/src/git.rs
+++ b/src/git.rs
@@ -119,9 +119,9 @@ pub fn update_commit_template(active_buddies: &Buddies) -> Result<()> {
     if !active_buddies.buddies.is_empty() {
         if !new_content.is_empty() {
             new_content.push('\n');
-            new_content.push('\n');
         }
 
+        new_content.push('\n');
         new_content.push_str(BEGIN_MARKER);
         new_content.push('\n');
 


### PR DESCRIPTION
always insert a newline before the git-squad section in the commit template to make co authors appear in the footer of the commit message