### PR TITLE
fix: make create command fail early on duplicate alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - always place co-authors in footer section of the commit
+- fail early on duplicate alias in `create` command
 
 ## 0.2.0 -- 2025-04-04
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod git;
 
 use anyhow::Result;
 use buddy::{Buddies, Buddy};
-use cli::{print_completions, Cli, Command};
+use cli::{Cli, Command, print_completions};
 use config::ConfigService;
 use std::io::{self, Write};
 
@@ -59,6 +59,10 @@ fn main() -> Result<()> {
                 buddies_file: cli.buddies_file.clone(),
             };
             let mut buddies = conf.load_buddies()?;
+
+            if buddies.has(&alias) {
+                anyhow::bail!("Buddy with alias '{}' already exists", alias)
+            }
 
             print!("Enter name for buddy '{}': ", alias);
             io::stdout().flush()?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -436,15 +436,11 @@ fn test_create_duplicate_buddy() -> Result<(), Box<dyn std::error::Error>> {
     cmd.args(&["--buddies-file", &buddies_path, "create", "peter"])
         .current_dir(&repo_path);
 
-    let mut child = cmd
+    let child = cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
-    {
-        let mut stdin = child.stdin.take().expect("Failed to open stdin");
-        stdin.write_all(b"Another Peter\nanother@neverland.com\n")?;
-    }
 
     let output = child.wait_with_output()?;
     let error_output = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
Add a check to detect an existing alias before prompting for name and email and gives users immediate feedback and avoids making them provide unnecessary input when the alias is invalid.