### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `git-squad` will be documented in this file.
 
 
+## [0.3.0](https://github.com/ccntrq/git-squad/compare/v0.2.0...v0.3.0) - 2025-04-15
+
+### ⛰️ Features
+
+- allow passing multiple buddies to `with` and `without` ([#1](https://github.com/ccntrq/git-squad/issues/1))
+- add autocomplete for buddies aliases ([#2](https://github.com/ccntrq/git-squad/issues/2))
+- [**breaking**] new toml format for buddies file ([#17](https://github.com/ccntrq/git-squad/issues/17))
+  **BREAKING CHANGE**: `yaml` buddies configs have been deprecated in favor of
+  `toml`. For users using the default config locations the old config will
+  be automatically migrated to the new format. For users using custom
+  `--buddies-file` locations there is a new command `git-squad
+  migrate-buddies` that can be used to perform the migration
+
+### 🐛 Bug Fixes
+
+- always place co-authors into the footer section ([#8](https://github.com/ccntrq/git-squad/issues/8))
+- make create command fail early on duplicate alias ([#9](https://github.com/ccntrq/git-squad/issues/9))
+
+### 📚 Documentation
+
+- add demo tape ([#10](https://github.com/ccntrq/git-squad/issues/10))
+
 ## 0.2.0 -- 2025-04-04
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "git-squad"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-squad"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Manage co-authors in git commit messages with ease"
 authors = ["Alexander Pankoff <ccntrq@screenri.de>"]


### PR DESCRIPTION



## 🤖 New release

* `git-squad`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/ccntrq/git-squad/compare/v0.2.0...v0.3.0) - 2025-04-15

### ⛰️ Features

- allow passing multiple buddies to `with` and `without` ([#1](https://github.com/ccntrq/git-squad/issues/1))
- add autocomplete for buddies aliases ([#2](https://github.com/ccntrq/git-squad/issues/2))
- [**breaking**] new toml format for buddies file ([#17](https://github.com/ccntrq/git-squad/issues/17))
  **BREAKING CHANGE**: `yaml` buddies configs have been deprecated in favor of
  `toml`. For users using the default config locations the old config will
  be automatically migrated to the new format. For users using custom
  `--buddies-file` locations there is a new command `git-squad
  migrate-buddies` that can be used to perform the migration

### 🐛 Bug Fixes

- always place co-authors into the footer section ([#8](https://github.com/ccntrq/git-squad/issues/8))
- make create command fail early on duplicate alias ([#9](https://github.com/ccntrq/git-squad/issues/9))

### 📚 Documentation

- add demo tape ([#10](https://github.com/ccntrq/git-squad/issues/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).