### PR TITLE
feat!: new toml format for buddies file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "test-case",
+ "toml",
 ]
 
 [[package]]
@@ -506,6 +507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +621,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -749,6 +793,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+toml = "0.8"
 anyhow = "1.0"
 dirs = "6.0"
 regex = "1.11"

--- a/README.md
+++ b/README.md
@@ -24,19 +24,20 @@ Manage co-authors in git commit messages with ease
 Usage: git-squad [OPTIONS] [COMMAND]
 
 Commands:
-  with         Add buddies to the current session
-  without      Remove buddies from the current session
-  alone        Remove all buddies from the current session
-  create       Create a new buddy
-  forget       Delete a buddy from the list of available buddies
-  info         List both active and available buddies
-  list         List all available buddies
-  active       List active buddies in the current session
-  completions  Generate completions for your shell
-  help         Print this message or the help of the given subcommand(s)
+  with             Add buddies to the current session
+  without          Remove buddies from the current session
+  alone            Remove all buddies from the current session
+  create           Create a new buddy
+  forget           Delete a buddy from the list of available buddies
+  info             List both active and available buddies
+  list             List all available buddies
+  active           List active buddies in the current session
+  completions      Generate completions for your shell
+  migrate-buddies  Migrate buddies from old yaml format to new toml format
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
-      --buddies-file <BUDDIES_FILE>  Use a custom buddy file instead of ~/.config/git-squad/buddies.yaml
+      --buddies-file <BUDDIES_FILE>  Use a custom buddy file instead of ~/.config/git-squad/buddies.toml
   -h, --help                         Print help
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ pub struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// Use a custom buddy file instead of ~/.config/git-squad/buddies.yaml
+    /// Use a custom buddy file instead of ~/.config/git-squad/buddies.toml
     #[arg(long = "buddies-file", global = true)]
     pub buddies_file: Option<PathBuf>,
 }
@@ -100,6 +100,14 @@ pub enum Command {
 
     /// Generate completions for your shell
     Completions { shell: Shell },
+
+    /// Migrate buddies from old yaml format to new toml format
+    MigrateBuddies {
+    /// Optional location of the old buddies file to use instead of
+    /// ~/.config/git-squad/buddies.yaml
+    #[arg(long = "old-buddies-file")]
+    old_buddies_file: Option<PathBuf>,
+    }
 }
 
 fn alias_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,11 +31,75 @@ impl FileConfig {
         Ok(self
             .buddies_file
             .clone()
-            .unwrap_or(FileConfig::get_config_dir()?.join("buddies.yaml")))
+            .unwrap_or(FileConfig::get_config_dir()?.join("buddies.toml")))
     }
 }
 
 impl ConfigService for FileConfig {
+    fn load_buddies(&self) -> Result<Buddies> {
+        let path = self.get_buddies_file()?;
+
+        if !path.exists() {
+            return Ok(Buddies::default());
+        }
+
+        let mut file = File::open(path).context("Failed to open config file")?;
+
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .context("Failed to read config file")?;
+
+        if contents.trim().is_empty() {
+            return Ok(Buddies::default());
+        }
+
+        toml::from_str(&contents).context("Failed to parse config")
+    }
+
+    fn save_buddies(&self, config: &Buddies) -> Result<()> {
+        let path = self.get_buddies_file()?;
+
+        let contents = toml::to_string(config).context("Failed to serialize config")?;
+
+        let mut file = File::create(path).context("Failed to create config file")?;
+
+        file.write_all(contents.as_bytes())
+            .context("Failed to write to buddies file")?;
+
+        Ok(())
+    }
+}
+
+#[deprecated(
+    since = "0.3.0",
+    note = "please use toml config with `FileConfig` instead"
+)]
+pub struct DeprecatedFileConfig {
+    pub buddies_file: Option<PathBuf>,
+}
+
+#[allow(deprecated)]
+impl DeprecatedFileConfig {
+    #[deprecated(
+        since = "0.3.0",
+        note = "please use toml config with `FileConfig::get_config_file` instead"
+    )]
+    pub fn get_buddies_file(&self) -> Result<PathBuf> {
+        Ok(self
+            .buddies_file
+            .clone()
+            .unwrap_or(FileConfig::get_config_dir()?.join("buddies.yaml")))
+    }
+
+    pub fn migrate(&self, to: &FileConfig) -> Result<()> {
+        let buddies = self.load_buddies()?;
+
+        to.save_buddies(&buddies)
+    }
+}
+
+#[allow(deprecated)]
+impl ConfigService for DeprecatedFileConfig {
     fn load_buddies(&self) -> Result<Buddies> {
         let path = self.get_buddies_file()?;
 


### PR DESCRIPTION
The default buddies file format is now `toml` the old `yaml` format is deprecated and shouldn't be used anymore

BREAKING-CHANGE: `yaml` buddies configs have been deprecated in favor of `toml`. For users using the default config locations the old config will be automatically migrated to the new format. For users using custom `--buddies-file` locations there is a new command `git-squad migrate-buddies` that can be used to perform the migration