### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `git-squad` will be documented in this file.
 
 
+## [0.3.1](https://github.com/ccntrq/git-squad/compare/v0.3.0...v0.3.1) - 2025-04-17
+
+### 📚 Documentation
+
+- make demo tape gif show on crates.io ([#20](https://github.com/ccntrq/git-squad/issues/20))
+
 ## [0.3.0](https://github.com/ccntrq/git-squad/compare/v0.2.0...v0.3.0) - 2025-04-15
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "git-squad"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-squad"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Manage co-authors in git commit messages with ease"
 authors = ["Alexander Pankoff <ccntrq@screenri.de>"]


### PR DESCRIPTION



## 🤖 New release

* `git-squad`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/ccntrq/git-squad/compare/v0.3.0...v0.3.1) - 2025-04-17

### 📚 Documentation

- make demo tape gif show on crates.io ([#20](https://github.com/ccntrq/git-squad/issues/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).