### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `git-squad` will be documented in this file.
 
 
+## [0.3.3](https://github.com/ccntrq/git-squad/compare/v0.3.2...v0.3.3) - 2025-05-22
+
+### ⛰️ Features
+
+- add multiselect menu for `with` and `without` command ([#35](https://github.com/ccntrq/git-squad/issues/35))
+- reimplement integration test suite ([#38](https://github.com/ccntrq/git-squad/issues/38))
+- improved prompts for create command ([#39](https://github.com/ccntrq/git-squad/issues/39))
+
+### 🐛 Bug Fixes
+
+- place Co-Authors in footer section ([#23](https://github.com/ccntrq/git-squad/issues/23))
+
 ## [0.3.2](https://github.com/ccntrq/git-squad/compare/v0.3.1...v0.3.2) - 2025-04-17
 
 ### 📚 Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "git-squad"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-squad"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "Manage co-authors in git commit messages with ease"
 authors = ["Alexander Pankoff <ccntrq@screenri.de>"]


### PR DESCRIPTION



## 🤖 New release

* `git-squad`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/ccntrq/git-squad/compare/v0.3.2...v0.3.3) - 2025-05-22

### ⛰️ Features

- add multiselect menu for `with` and `without` command ([#35](https://github.com/ccntrq/git-squad/issues/35))
- reimplement integration test suite ([#38](https://github.com/ccntrq/git-squad/issues/38))
- improved prompts for create command ([#39](https://github.com/ccntrq/git-squad/issues/39))

### 🐛 Bug Fixes

- place Co-Authors in footer section ([#23](https://github.com/ccntrq/git-squad/issues/23))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).